### PR TITLE
Feat: Integrate Local Ollama(Gemma3) for AI summarization

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,6 +125,7 @@ Supported models
  -  `gemini-2.0-pro-exp-02-05`
  -  `gemini-2.5-flash-preview-04-17`
  -  `gemini-2.5-pro-preview-03-25`
+ -  `gemma3`
  -  `gpt-4.1`
  -  `gpt-4.5-preview`
  -  `gpt-4o-mini`

--- a/cspell.json
+++ b/cspell.json
@@ -7,6 +7,7 @@
     "langchain",
     "logtape",
     "Minhee",
+    "ollama",
     "paoramen",
     "tinyld",
     "yoyak"

--- a/deno.json
+++ b/deno.json
@@ -20,6 +20,7 @@
     "@langchain/deepseek": "npm:@langchain/deepseek@^0.0.1",
     "@langchain/google-genai": "npm:@langchain/google-genai@^0.1.8",
     "@langchain/openai": "npm:@langchain/openai@^0.4.2",
+    "@langchain/ollama": "npm:@langchain/ollama@^0.2.1",
     "@logtape/logtape": "jsr:@logtape/logtape@^0.8.2",
     "@paoramen/cheer-reader": "jsr:@paoramen/cheer-reader@^0.1.2",
     "@std/fs": "jsr:@std/fs@^1.0.11",

--- a/deno.lock
+++ b/deno.lock
@@ -1,5 +1,5 @@
 {
-  "version": "4",
+  "version": "5",
   "specifiers": {
     "jsr:@cliffy/ansi@1.0.0-rc.7": "1.0.0-rc.7",
     "jsr:@cliffy/command@^1.0.0-rc.7": "1.0.0-rc.7",
@@ -37,7 +37,9 @@
     "npm:@langchain/core@~0.3.37": "0.3.37_zod@3.24.1",
     "npm:@langchain/deepseek@^0.0.1": "0.0.1_@langchain+core@0.3.37__zod@3.24.1",
     "npm:@langchain/google-genai@~0.1.8": "0.1.8_@langchain+core@0.3.37__zod@3.24.1",
+    "npm:@langchain/ollama@~0.2.1": "0.2.1_@langchain+core@0.3.37__zod@3.24.1_zod@3.24.1",
     "npm:@langchain/openai@~0.4.2": "0.4.2_@langchain+core@0.3.37__zod@3.24.1_zod@3.24.1_openai@4.82.0__zod@3.24.1",
+    "npm:@types/node@*": "22.15.15",
     "npm:chardet@2": "2.0.0",
     "npm:cheerio@1": "1.0.0",
     "npm:cheerio@^1.0.0-rc.12": "1.0.0",
@@ -228,7 +230,7 @@
         "camelcase",
         "decamelize",
         "js-tiktoken",
-        "langsmith@0.3.4",
+        "langsmith@0.3.4_openai@4.82.0__zod@3.24.1_zod@3.24.1",
         "mustache",
         "p-queue",
         "p-retry",
@@ -270,6 +272,16 @@
         "zod-to-json-schema"
       ]
     },
+    "@langchain/ollama@0.2.1_@langchain+core@0.3.37__zod@3.24.1_zod@3.24.1": {
+      "integrity": "sha512-9WQ/rJV002n2f/aBPzNKBZU7kJfhqDnaGTWeIKO5gM0wZ+Rb2mfk7psluFIedachwsM/FQ+oIBcViHriaXngzA==",
+      "dependencies": [
+        "@langchain/core@0.3.37_zod@3.24.1",
+        "ollama",
+        "uuid",
+        "zod",
+        "zod-to-json-schema"
+      ]
+    },
     "@langchain/openai@0.4.2_@langchain+core@0.3.37__zod@3.24.1_zod@3.24.1_openai@4.82.0__zod@3.24.1": {
       "integrity": "sha512-Cuj7qbVcycALTP0aqZuPpEc7As8cwiGaU21MhXRyZFs+dnWxKYxZ1Q1z4kcx6cYkq/I+CNwwmk+sP+YruU73Aw==",
       "dependencies": [
@@ -294,6 +306,12 @@
       "integrity": "sha512-RE+K0+KZoEpDUbGGctnGdkrLFwi1eYKTlIHNl2Um98mUkGsm1u2Ff6Ltd0e8DktTtC98uy7rSj+hO8t/QuLoVQ==",
       "dependencies": [
         "undici-types@5.26.5"
+      ]
+    },
+    "@types/node@22.15.15": {
+      "integrity": "sha512-R5muMcZob3/Jjchn5LcO8jdKwSCbzqmPB6ruBxMcf9kbxtniZHP327s6C37iOfuw8mbKK3cAQa7sEl7afLrQ8A==",
+      "dependencies": [
+        "undici-types@6.21.0"
       ]
     },
     "@types/node@22.5.4": {
@@ -463,7 +481,8 @@
       "integrity": "sha512-y655CeyUQ+jj7KBbYMc4FG01V8ZQqjN+gDYGJ50RtfsUB8iG9AmwmwoAgeKLJdmueKKMrH1RJ7yXHTSoczdv5w==",
       "dependencies": [
         "strnum"
-      ]
+      ],
+      "bin": true
     },
     "form-data-encoder@1.7.2": {
       "integrity": "sha512-qfqtYan3rxrnCk1VYaA4H+Ms9xdpPqvLZa6xmMgFvhO32x7/3J/ExcTd6qpxM0vH2GdMI+poehyBZvqfMTto8A=="
@@ -523,6 +542,9 @@
         "p-retry",
         "semver",
         "uuid"
+      ],
+      "optionalPeers": [
+        "openai"
       ]
     },
     "langsmith@0.3.4_openai@4.82.0__zod@3.24.1_zod@3.24.1": {
@@ -536,6 +558,9 @@
         "p-retry",
         "semver",
         "uuid"
+      ],
+      "optionalPeers": [
+        "openai"
       ]
     },
     "mime-db@1.52.0": {
@@ -551,10 +576,12 @@
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
     },
     "mustache@4.2.0": {
-      "integrity": "sha512-71ippSywq5Yb7/tVYyGbkBggbU8H3u5Rz56fH60jGFgr8uHwxs+aSKeqmluIVzM0m0kB7xQjKS6qPfd0b2ZoqQ=="
+      "integrity": "sha512-71ippSywq5Yb7/tVYyGbkBggbU8H3u5Rz56fH60jGFgr8uHwxs+aSKeqmluIVzM0m0kB7xQjKS6qPfd0b2ZoqQ==",
+      "bin": true
     },
     "node-domexception@1.0.0": {
-      "integrity": "sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ=="
+      "integrity": "sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==",
+      "deprecated": true
     },
     "node-fetch@2.7.0": {
       "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
@@ -568,6 +595,12 @@
         "boolbase"
       ]
     },
+    "ollama@0.5.16": {
+      "integrity": "sha512-OEbxxOIUZtdZgOaTPAULo051F5y+Z1vosxEYOoABPnQKeW7i4O8tJNlxCB+xioyoorVqgjkdj+TA1f1Hy2ug/w==",
+      "dependencies": [
+        "whatwg-fetch"
+      ]
+    },
     "openai@4.82.0_zod@3.24.1": {
       "integrity": "sha512-1bTxOVGZuVGsKKUWbh3BEwX1QxIXUftJv+9COhhGGVDTFwiaOd4gWsMynF2ewj1mg6by3/O+U8+EEHpWRdPaJg==",
       "dependencies": [
@@ -579,7 +612,11 @@
         "formdata-node",
         "node-fetch",
         "zod"
-      ]
+      ],
+      "optionalPeers": [
+        "zod"
+      ],
+      "bin": true
     },
     "p-finally@1.0.0": {
       "integrity": "sha512-LICb2p9CB7FS+0eR1oqWnHhp0FljGLZCWBE9aix0Uye9W8LTQPwMTYVGWQWIw9RdQiDg4+epXQODwIYJtSJaow=="
@@ -630,7 +667,8 @@
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
     },
     "semver@7.7.1": {
-      "integrity": "sha512-hlq8tAfn0m/61p4BVRcPzIGr6LKiMwo4VM6dGi6pt4qcRkmNzTcWq6eCEjEh+qXjkMDvPlOFFSGwQjoEa6gyMA=="
+      "integrity": "sha512-hlq8tAfn0m/61p4BVRcPzIGr6LKiMwo4VM6dGi6pt4qcRkmNzTcWq6eCEjEh+qXjkMDvPlOFFSGwQjoEa6gyMA==",
+      "bin": true
     },
     "simple-wcswidth@1.0.1": {
       "integrity": "sha512-xMO/8eNREtaROt7tJvWJqHBDTMFN4eiQ5I4JRMuilwfnFcV5W9u7RUkueNkdw0jPqGMX36iCywelS5yilTuOxg=="
@@ -645,7 +683,8 @@
       ]
     },
     "tinyld@1.3.4": {
-      "integrity": "sha512-u26CNoaInA4XpDU+8s/6Cq8xHc2T5M4fXB3ICfXPokUQoLzmPgSZU02TAkFwFMJCWTjk53gtkS8pETTreZwCqw=="
+      "integrity": "sha512-u26CNoaInA4XpDU+8s/6Cq8xHc2T5M4fXB3ICfXPokUQoLzmPgSZU02TAkFwFMJCWTjk53gtkS8pETTreZwCqw==",
+      "bin": true
     },
     "tr46@0.0.3": {
       "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="
@@ -662,11 +701,15 @@
     "undici-types@6.19.8": {
       "integrity": "sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw=="
     },
+    "undici-types@6.21.0": {
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ=="
+    },
     "undici@6.21.0": {
       "integrity": "sha512-BUgJXc752Kou3oOIuU1i+yZZypyZRqNPW0vqoMPl8VaoalSfeR0D8/t4iAS3yirs79SSMTxTag+ZC86uswv+Cw=="
     },
     "uuid@10.0.0": {
-      "integrity": "sha512-8XkAphELsDnEGrDxUOHB3RGvXz6TeuYSGEZBOjtTtPm2lwhGBjLgOzLHB63IUWfBpNucQjND6d3AOudO+H3RWQ=="
+      "integrity": "sha512-8XkAphELsDnEGrDxUOHB3RGvXz6TeuYSGEZBOjtTtPm2lwhGBjLgOzLHB63IUWfBpNucQjND6d3AOudO+H3RWQ==",
+      "bin": true
     },
     "web-streams-polyfill@4.0.0-beta.3": {
       "integrity": "sha512-QW95TCTaHmsYfHDybGMwO5IJIM93I/6vTRk+daHTWFPhwh+C8Cg7j7XyKrwrj8Ib6vYXe0ocYNrmzY4xAAN6ug=="
@@ -679,6 +722,9 @@
       "dependencies": [
         "iconv-lite"
       ]
+    },
+    "whatwg-fetch@3.6.20": {
+      "integrity": "sha512-EqhiFU6daOA8kpjOWTL0olhVOF3i7OrFzSYiGsEMB8GcXS+RrzauAERX65xMeNWVqxA6HXH2m69Z9LaKKdisfg=="
     },
     "whatwg-mimetype@4.0.0": {
       "integrity": "sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg=="
@@ -716,6 +762,7 @@
       "npm:@langchain/core@~0.3.37",
       "npm:@langchain/deepseek@^0.0.1",
       "npm:@langchain/google-genai@~0.1.8",
+      "npm:@langchain/ollama@~0.2.1",
       "npm:@langchain/openai@~0.4.2",
       "npm:chardet@2",
       "npm:cheerio@1",

--- a/src/models.ts
+++ b/src/models.ts
@@ -17,6 +17,7 @@ import { ChatAnthropic } from "@langchain/anthropic";
 import { HumanMessage } from "@langchain/core/messages";
 import { ChatDeepSeek } from "@langchain/deepseek";
 import { ChatGoogleGenerativeAI } from "@langchain/google-genai";
+import { ChatOllama } from "@langchain/ollama";
 import { ChatOpenAI } from "@langchain/openai";
 import { getLogger } from "@logtape/logtape";
 
@@ -44,6 +45,7 @@ export const modelMonikers = [
   "gemini-2.0-pro-exp-02-05",
   "gemini-2.5-flash-preview-04-17",
   "gemini-2.5-pro-preview-03-25",
+  "gemma3",
   "gpt-4.1",
   "gpt-4.5-preview",
   "gpt-4o",
@@ -77,7 +79,8 @@ export type Model =
   | ChatOpenAI
   | ChatAnthropic
   | ChatDeepSeek
-  | ChatGoogleGenerativeAI;
+  | ChatGoogleGenerativeAI
+  | ChatOllama;
 
 /**
  * The constructor of a model.
@@ -108,6 +111,7 @@ export const modelClasses: Record<ModelMoniker, ModelClass> = {
   "gemini-2.0-pro-exp-02-05": ChatGoogleGenerativeAI,
   "gemini-2.5-flash-preview-04-17": ChatGoogleGenerativeAI,
   "gemini-2.5-pro-preview-03-25": ChatGoogleGenerativeAI,
+  "gemma3": ChatOllama,
   "gpt-4.1": ChatOpenAI,
   "gpt-4.5-preview": ChatOpenAI,
   "gpt-4o": ChatOpenAI,


### PR DESCRIPTION
This Pull Request introduces support for using locally hosted Large Language Models (LLMs) via Ollama.

**Key Changes:**

* Integrated the `@langchain/ollama` package by adding `import { ChatOllama } from "@langchain/ollama";` in `src/models.ts`. This allows `yoyak` to interface with models served by a local Ollama instance.
* The model identifier `"gemma3"` has been added to the supported models list and is configured to use `ChatOllama`. This enables users to leverage the Gemma3 model (and other compatible models) running locally through Ollama for tasks like AI summarization.

**Requirements:**

To use this new feature, users must have:
1. Ollama installed and running on their local machine.
2. The desired model (e.g., `gemma3`) pulled via the Ollama CLI (e.g., `ollama pull gemma3`).

**How to Use:**

Once the requirements are met, users can configure `yoyak` to use the local Ollama model by running the existing `set-model` command:
```
yoyak set-model gemma3
```
Yoyak will then use the local `gemma3` model for its operations. The existing `yoyak summary` and other relevant commands remain unchanged in their usage.

This enhancement allows users to utilize powerful LLMs locally, offering benefits such as increased privacy, offline capabilities, and potentially reduced costs associated with cloud-based LLM APIs.